### PR TITLE
Update eisbrecher branch to latest (1.0.4) release.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,7 +31,12 @@ platforms:
 - name: oracle-6.4
   driver_config:
     box: oracle-6.4
-    box_url: https://dl.dropbox.com/sh/yim9oyqajopoiqs/G-XIEmQJMb/oracle64-64.box
+    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel64-64.box
+
+- name: oracle-6.5
+  driver_config:
+    box: oracle-6.5
+    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box
 
 - name: debian-6
   driver_config:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,11 +32,11 @@ platforms:
 - name: debian-6
   driver_config:
     box: debian-6
-    box_url: https://googledrive.com/host/0B83ZToJ3fGtDeE9KWm1sWndZdGs/debian-6.0.10-amd64_virtualbox.box
+    box_url: https://s3.eu-central-1.amazonaws.com/ffuenf-vagrantboxes/debian/debian-6.0.10-amd64_virtualbox.box
 - name: debian-7
   driver_config:
     box: debian-7
-    box_url: https://googledrive.com/host/0B83ZToJ3fGtDVC1DeVVzc3lkc0U/debian-7.6.0-amd64_virtualbox.box
+    box_url: https://s3.eu-central-1.amazonaws.com/ffuenf-vagrantboxes/debian/debian-7.7.0-amd64_virtualbox.box
 suites:
 - name: default
   manifest: site.pp

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,55 +1,42 @@
 ---
-
 driver:
   name: vagrant
-
 provisioner:
   name: puppet_apply
-  test_repo_uri: "https://github.com/TelekomLabs/tests-ssh-hardening.git"
-
+  test_repo_uri: https://github.com/TelekomLabs/tests-ssh-hardening.git
 platforms:
 - name: ubuntu-12.04
   driver_config:
     box: opscode-ubuntu-12.04
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
-
 - name: ubuntu-14.04
   driver_config:
     box: opscode-ubuntu-14.04
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
-
 - name: centos-6.4
   driver_config:
     box: opscode-centos-6.4
     box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
-
 - name: centos-6.5
   driver_config:
-     box: opscode-centos-6.5
-     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
-
+    box: opscode-centos-6.5
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
 - name: oracle-6.4
   driver_config:
     box: oracle-6.4
     box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel64-64.box
-
 - name: oracle-6.5
   driver_config:
     box: oracle-6.5
     box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box
-
 - name: debian-6
   driver_config:
     box: debian-6
-    # source: https://github.com/ffuenf/vagrant-boxes
-    box_url: https://googledrive.com/host/0B83ZToJ3fGtDeE9KWm1sWndZdGs/debian-6.0.9-amd64_virtualbox.box
-
+    box_url: https://googledrive.com/host/0B83ZToJ3fGtDeE9KWm1sWndZdGs/debian-6.0.10-amd64_virtualbox.box
 - name: debian-7
   driver_config:
     box: debian-7
-    # source: https://github.com/ffuenf/vagrant-boxes
-    box_url: https://googledrive.com/host/0B83ZToJ3fGtDVC1DeVVzc3lkc0U/debian-7.5.0-amd64_virtualbox.box
-
+    box_url: https://googledrive.com/host/0B83ZToJ3fGtDVC1DeVVzc3lkc0U/debian-7.6.0-amd64_virtualbox.box
 suites:
 - name: default
   manifest: site.pp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
+---
 AllCops:
   Exclude:
-    - vendor/**
-    - metadata.rb
-    - '**/Puppetfile'
-    - Puppetfile
-
+  - vendor/**/*
+  - test/**/*
+  - spec/fixtures/**/*
+  - Puppetfile
 Documentation:
   Enabled: false
 AlignParameters:
@@ -15,7 +15,15 @@ HashSyntax:
   Enabled: false
 LineLength:
   Enabled: false
+EmptyLinesAroundBlockBody:
+  Enabled: false
 MethodLength:
-  Max: 30
+  Max: 40
 NumericLiterals:
   MinDigits: 10
+Metrics/CyclomaticComplexity:
+  Max: 10
+Metrics/PerceivedComplexity:
+  Max: 10
+Metrics/AbcSize:
+  Max: 29

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: ruby
 bundler_args: --without development integration openstack
 env:
   - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.4.3"
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.6.0"
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1
+
+* feature: add back puppet 3.4.3 support
+* feature: make other SSH configuration options configurable
+* improvement: added faq on locked accounts to readme
+
 ## 1.0.0
 
 * feature: add support for oracle linux in crypto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.4
+
+* improvement: reprioritize EtM-based MACs
+* improvement: move SHA1 KEX algos from default to weak profile
+
 ## 1.0.3
 
 * feature: remove legacy SSHv1 code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.3
+
+* feature: remove legacy SSHv1 code
+* feature: add back GCM cipher
+
 ## 1.0.2
 
 * bugfix: pass allow_{tcp,agent}_forwarding from init to classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+* bugfix: pass allow_{tcp,agent}_forwarding from init to classes
+
 ## 1.0.1
 
 * feature: add back puppet 3.4.3 support

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 group :integration do
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
-  gem 'kitchen-puppet', '~> 0.0.11'
+  gem 'kitchen-puppet'
   gem 'librarian-puppet'
   gem 'kitchen-sharedtests', '~> 0.2.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-if puppetversion = ENV['PUPPET_VERSION']
+puppetversion = ENV['PUPPET_VERSION']
+if puppetversion
   gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false
@@ -10,9 +11,9 @@ group :test do
   gem 'rake'
   gem 'rspec-puppet'
   # avoid NoMethodError: private method `clone' called for #<RuboCop::Cop::CopStore:0x00000104e286c8>
-  gem 'puppetlabs_spec_helper', :git => "https://github.com/ehaselwanter/puppetlabs_spec_helper"
+  gem 'puppetlabs_spec_helper', :git => 'https://github.com/ehaselwanter/puppetlabs_spec_helper'
   gem 'puppet-lint'
-  gem 'rubocop',    '~> 0.23' if RUBY_VERSION > "1.9.2"
+  gem 'rubocop',    '~> 0.23' if RUBY_VERSION > '1.9.2'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# encoding: utf-8
 source 'https://rubygems.org'
 
 puppetversion = ENV['PUPPET_VERSION']

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 guard 'rake', :task => 'lint' do
-  watch(%r{^.*$})
+  watch(/^.*$/)
 end

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'hardening/ssh_hardening'
-version '1.0.1'
+version '1.0.2'
 source 'https://github.com/TelekomLabs/puppet-ssh-hardening'
 author 'Dominik Richter'
 license 'Apache License, Version 2.0'

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'hardening/ssh_hardening'
-version '1.0.3'
+version '1.0.4'
 source 'https://github.com/TelekomLabs/puppet-ssh-hardening'
 author 'Dominik Richter'
 license 'Apache License, Version 2.0'

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'hardening/ssh_hardening'
-version '1.0.2'
+version '1.0.3'
 source 'https://github.com/TelekomLabs/puppet-ssh-hardening'
 author 'Dominik Richter'
 license 'Apache License, Version 2.0'

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'hardening/ssh_hardening'
-version '1.0.0'
+version '1.0.1'
 source 'https://github.com/TelekomLabs/puppet-ssh-hardening'
 author 'Dominik Richter'
 license 'Apache License, Version 2.0'

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you find this isn't enough, feel free to activate `cbc_required` for ciphers,
 * Edmund Haselwanter [ehaselwanter](https://github.com/ehaselwanter)
 * Christoph Hartmann [chris-rock](https://github.com/chris-rock)
 * Patrick Meier [atomic111](https://github.com/atomic111)
+* Matthew Haughton [3flex](https://github.com/3flex)
 * Kurt Huwig [kurthuwig](https://github.com/kurthuwig)
 * Artem Sidorenko [artem-sidorenko](https://github.com/artem-sidorenko)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This module provides secure ssh-client and ssh-server configurations.
 * `allow_tcp_forwarding = false` - set to true to allow TCP forwarding
 * `allow_agent_forwarding = false` - set to true to allow Agent forwarding
 * `use_pam = false` to disable pam authentication
+* `client_options = {}` - set values in the hash to override the module's settings
+* `server_options = {}` - set values in the hash to override the module's settings
 
 ## Usage
 
@@ -43,6 +45,19 @@ You should configure core attributes:
 
 **The default value for `listen_to` is `0.0.0.0`. It is highly recommended to change the value.**
 
+### Overwriting default options
+Default options will be merged with options passed in by the `client_options` and `server_options` parameters.
+If an option is set both as default and via options parameter, the latter will win.
+
+The following example will enable X11Forwarding, which is disabled by default:
+
+```puppet
+class { 'ssh_hardening':
+  server_options => {
+    'X11Forwarding' => 'yes',
+  },
+}
+```
 
 ## FAQ / Pitfalls
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ The proper way to solve this is to unlock the account (`passwd -u myuser`). If t
 
 Alternatively, if you intend to use PAM, you enabled it via `use_pam = true`. PAM will allow locked users to get in with keys.
 
+
+**Why doesn't my application connect via SSH anymore?**
+
+Always look into log files first and if possible look at the negotation between client and server that is completed when connecting.
+
+We have seen some issues in applications (based on python and ruby) that are due to their use of an outdated crypto set. This collides with this hardening module, which reduced the list of ciphers, message authentication codes (MACs) and key exchange (KEX) algorithms to a more secure selection.
+
+If you find this isn't enough, feel free to activate `cbc_required` for ciphers, `weak_hmac` for MACs, and `weak_kex` for KEX.
+
 ## Contributors + Kudos
 
 * Edmund Haselwanter [ehaselwanter](https://github.com/ehaselwanter)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ You should configure core attributes:
 **The default value for `listen_to` is `0.0.0.0`. It is highly recommended to change the value.**
 
 
+## FAQ / Pitfalls
+
+**I can't log into my account. I have registered the client key, but it still doesn't let me it.**
+
+If you have exhausted all typical issues (firewall, network, key missing, wrong key, account disabled etc.), it may be that your account is locked. The quickest way to find out is to look at the password hash for your user:
+
+    sudo grep myuser /etc/shadow
+
+If the hash includes an `!`, your account is locked:
+
+    myuser:!:16280:7:60:7:::
+
+The proper way to solve this is to unlock the account (`passwd -u myuser`). If the user doesn't have a password, you should can unlock it via:
+
+    usermod -p "*" myuser
+
+Alternatively, if you intend to use PAM, you enabled it via `use_pam = true`. PAM will allow locked users to get in with keys.
+
 ## Contributors + Kudos
 
 * Edmund Haselwanter [ehaselwanter](https://github.com/ehaselwanter)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This module provides secure ssh-client and ssh-server configurations.
 * `remote_hosts` - one or more hosts, to which ssh-client can connect to. Default is empty, but should be configured for security reasons!
 * `allow_tcp_forwarding = false` - set to true to allow TCP forwarding
 * `allow_agent_forwarding = false` - set to true to allow Agent forwarding
+* `use_pam = false` to disable pam authentication
 
 ## Usage
 

--- a/lib/puppet/parser/functions/get_ssh_ciphers.rb
+++ b/lib/puppet/parser/functions/get_ssh_ciphers.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 Puppet::Parser::Functions.newfunction(:get_ssh_ciphers, :type => :rvalue) do |args|
   os = args[0].downcase

--- a/lib/puppet/parser/functions/get_ssh_ciphers.rb
+++ b/lib/puppet/parser/functions/get_ssh_ciphers.rb
@@ -26,7 +26,7 @@ Puppet::Parser::Functions.newfunction(:get_ssh_ciphers, :type => :rvalue) do |ar
   ciphers_53['weak'] = ciphers_53['default'] + ',aes256-cbc,aes192-cbc,aes128-cbc'
 
   ciphers_66 = {}
-  ciphers_66.default = 'chacha20-poly1305@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+  ciphers_66.default = 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
   ciphers_66['weak'] = ciphers_66['default'] + ',aes256-cbc,aes192-cbc,aes128-cbc'
 
   # creat the default version map (if os + version are default)

--- a/lib/puppet/parser/functions/get_ssh_kex.rb
+++ b/lib/puppet/parser/functions/get_ssh_kex.rb
@@ -22,12 +22,12 @@ Puppet::Parser::Functions.newfunction(:get_ssh_kex, :type => :rvalue) do |args|
   weak_kex = args[2] ? 'weak' : 'default'
 
   kex_59 = {}
-  kex_59.default = 'diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
-  kex_59['weak'] = kex_59['default'] + ',diffie-hellman-group1-sha1'
+  kex_59.default = 'diffie-hellman-group-exchange-sha256'
+  kex_59['weak'] = kex_59['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
 
   kex_66 = {}
-  kex_66.default = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
-  kex_66['weak'] = kex_66['default'] + ',diffie-hellman-group1-sha1'
+  kex_66.default = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
+  kex_66['weak'] = kex_66['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
 
   # creat the default version map (if os + version are default)
   default_vmap = {}

--- a/lib/puppet/parser/functions/get_ssh_kex.rb
+++ b/lib/puppet/parser/functions/get_ssh_kex.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 Puppet::Parser::Functions.newfunction(:get_ssh_kex, :type => :rvalue) do |args|
   os = args[0].downcase

--- a/lib/puppet/parser/functions/get_ssh_macs.rb
+++ b/lib/puppet/parser/functions/get_ssh_macs.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 Puppet::Parser::Functions.newfunction(:get_ssh_macs, :type => :rvalue) do |args|
   os = args[0].downcase

--- a/lib/puppet/parser/functions/get_ssh_macs.rb
+++ b/lib/puppet/parser/functions/get_ssh_macs.rb
@@ -29,7 +29,7 @@ Puppet::Parser::Functions.newfunction(:get_ssh_macs, :type => :rvalue) do |args|
   macs_59['weak'] = macs_59['default'] + ',hmac-sha1'
 
   macs_66 = {}
-  macs_66.default = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-512,hmac-sha2-256-etm@openssh.com,hmac-sha2-256,umac-128-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-ripemd160'
+  macs_66.default = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
   macs_66['weak'] = macs_66['default'] + ',hmac-sha1'
 
   # creat the default version map (if os + version are default)

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -29,11 +29,15 @@
 # [*ipv6_enabled*]
 #   Set to true if you need IPv6 support in SSH.
 #
+# [*options*]
+#   Allow override of default settings provided by the module.
+#
 class ssh_hardening::client (
   $cbc_required = false,
   $weak_hmac = false,
   $weak_kex = false,
   $ports = [ 22 ],
+  $options      = {},
   $ipv6_enabled = false
 ) {
   if $ipv6_enabled == true {
@@ -135,8 +139,10 @@ class ssh_hardening::client (
     #VisualHostKey yes
   }
 
+  $merged_options = merge($ssh_options, $options)
+
   class { 'ssh::client':
     storeconfigs_enabled => false,
-    options              => delete_undef_values($ssh_options),
+    options              => delete_undef_values($merged_options),
   }
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,3 +1,10 @@
+# === Copyright
+#
+# Copyright 2014, Deutsche Telekom AG
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
 # == Class: ssh_hardening::client
 #
 # The default SSH class which installs the SSH client
@@ -21,10 +28,6 @@
 #
 # [*ipv6_enabled*]
 #   Set to true if you need IPv6 support in SSH.
-#
-# === Copyright
-#
-# Copyright 2014, Deutsche Telekom AG
 #
 class ssh_hardening::client (
   $cbc_required = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,10 @@
+# === Copyright
+#
+# Copyright 2014, Deutsche Telekom AG
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
 # == Class: ssh_hardening
 #
 # The default SSH class which installs the SSH server and client
@@ -46,10 +53,6 @@
 #
 # [*allow_agent_forwarding*]
 #   Set to true to allow Agent forwarding
-#
-# === Copyright
-#
-# Copyright 2014, Deutsche Telekom AG
 #
 class ssh_hardening(
   $cbc_required          = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,12 @@
 # [*allow_agent_forwarding*]
 #   Set to true to allow Agent forwarding
 #
+# [*server_options*]
+#   Allow override of default server settings provided by the module.
+#
+# [*client_options*]
+#   Allow override of default client settings provided by the module.
+#
 class ssh_hardening(
   $cbc_required          = false,
   $weak_hmac             = false,
@@ -72,6 +78,8 @@ class ssh_hardening(
   $use_pam               = false,
   $allow_tcp_forwarding   = false,
   $allow_agent_forwarding = false,
+  $server_options         = {},
+  $client_options         = {},
 ) {
   class { 'ssh_hardening::server':
     cbc_required           => $cbc_required,
@@ -87,6 +95,7 @@ class ssh_hardening(
     use_pam                => $use_pam,
     allow_tcp_forwarding   => false,
     allow_agent_forwarding => false,
+    options                => $server_options,
   }
   class { 'ssh_hardening::client':
     ipv6_enabled => $ipv6_enabled,
@@ -94,5 +103,6 @@ class ssh_hardening(
     cbc_required => $cbc_required,
     weak_hmac    => $weak_hmac,
     weak_kex     => $weak_kex,
+    options      => $client_options,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,8 +93,8 @@ class ssh_hardening(
     allow_root_with_key    => $allow_root_with_key,
     ipv6_enabled           => $ipv6_enabled,
     use_pam                => $use_pam,
-    allow_tcp_forwarding   => false,
-    allow_agent_forwarding => false,
+    allow_tcp_forwarding   => $allow_tcp_forwarding,
+    allow_agent_forwarding => $allow_agent_forwarding,
     options                => $server_options,
   }
   class { 'ssh_hardening::client':

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,3 +1,10 @@
+# === Copyright
+#
+# Copyright 2014, Deutsche Telekom AG
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
 # == Class: ssh_hardening::server
 #
 # The default SSH class which installs the SSH server
@@ -40,10 +47,6 @@
 #
 # [*ipv6_enabled*]
 #   Set to true if you need IPv6 support in SSH.
-#
-# === Copyright
-#
-# Copyright 2014, Deutsche Telekom AG
 #
 class ssh_hardening::server (
   $cbc_required           = false,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -164,10 +164,6 @@ class ssh_hardening::server (
       #
       'KexAlgorithms'                   => $kex,
 
-      # Lifetime and size of ephemeral version 1 server key
-      'KeyRegenerationInterval'         => '1h',
-      'ServerKeyBits'                   => 2048,
-
       # Authentication
       # --------------
 
@@ -181,13 +177,11 @@ class ssh_hardening::server (
       'MaxStartups'                     => '10:30:100',
 
       # Enable public key authentication
-      'RSAAuthentication'               => 'yes',
       'PubkeyAuthentication'            => 'yes',
 
       # Never use host-based authentication. It can be exploited.
       'IgnoreRhosts'                    => 'yes',
       'IgnoreUserKnownHosts'            => 'yes',
-      'RhostsRSAAuthentication'         => 'no',
       'HostbasedAuthentication'         => 'no',
 
       # Disable password-based authentication, it can allow for

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -48,6 +48,9 @@
 # [*ipv6_enabled*]
 #   Set to true if you need IPv6 support in SSH.
 #
+# [*options*]
+#   Allow override of default settings provided by the module.
+#
 class ssh_hardening::server (
   $cbc_required           = false,
   $weak_hmac              = false,
@@ -62,6 +65,7 @@ class ssh_hardening::server (
   $use_pam                = false,
   $allow_tcp_forwarding   = false,
   $allow_agent_forwarding = false,
+  $options                = {},
 ) {
 
   $addressfamily = $ipv6_enabled ? {
@@ -93,9 +97,7 @@ class ssh_hardening::server (
     false => 'no'
   }
 
-  class { 'ssh::server':
-    storeconfigs_enabled => false,
-    options              => {
+    $default_hardened_options = {
       # Basic configuration
       # ===================
 
@@ -272,7 +274,13 @@ class ssh_hardening::server (
       #PasswordAuthentication no
       #PermitRootLogin no
       #X11Forwarding no
-    },
+    }
+
+  $merged_options = merge($default_hardened_options, $options)
+
+  class { 'ssh::server':
+    storeconfigs_enabled => false,
+    options              => $merged_options,
   }
 
   file {'/etc/ssh':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hardening-ssh_hardening",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "source": "https://github.com/TelekomLabs/puppet-ssh-hardening",
   "author": "Dominik Richter",
   "license": "Apache License, Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hardening/ssh_hardening",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "source": "https://github.com/TelekomLabs/puppet-ssh-hardening",
   "author": "Dominik Richter",
   "license": "Apache License, Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hardening-ssh_hardening",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "source": "https://github.com/TelekomLabs/puppet-ssh-hardening",
   "author": "Dominik Richter",
   "license": "Apache License, Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hardening/ssh_hardening",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "source": "https://github.com/TelekomLabs/puppet-ssh-hardening",
   "author": "Dominik Richter",
   "license": "Apache License, Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "hardening/ssh_hardening",
+  "name": "hardening-ssh_hardening",
   "version": "1.0.2",
   "source": "https://github.com/TelekomLabs/puppet-ssh-hardening",
   "author": "Dominik Richter",

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require 'spec_helper'
 

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require 'spec_helper'
 

--- a/spec/functions/get_ssh_ciphers_spec.rb
+++ b/spec/functions/get_ssh_ciphers_spec.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require 'spec_helper'
 

--- a/spec/functions/get_ssh_kex_spec.rb
+++ b/spec/functions/get_ssh_kex_spec.rb
@@ -26,7 +26,7 @@ describe 'get_ssh_kex' do
   end
 
   it 'should get the correct kex (default)' do
-    scope.function_get_ssh_kex(['', '', false]).should eq('diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1')
+    scope.function_get_ssh_kex(['', '', false]).should eq('diffie-hellman-group-exchange-sha256')
   end
 
   it 'should get the correct kex (default weak)' do
@@ -34,7 +34,7 @@ describe 'get_ssh_kex' do
   end
 
   it 'should get the correct kex (ubuntu 12.04, default)' do
-    scope.function_get_ssh_kex(['ubuntu', '12.04', false]).should eq('diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1')
+    scope.function_get_ssh_kex(['ubuntu', '12.04', false]).should eq('diffie-hellman-group-exchange-sha256')
   end
 
   it 'should get the correct kex (ubuntu 12.04, weak)' do

--- a/spec/functions/get_ssh_kex_spec.rb
+++ b/spec/functions/get_ssh_kex_spec.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require 'spec_helper'
 

--- a/spec/functions/get_ssh_macs_spec.rb
+++ b/spec/functions/get_ssh_macs_spec.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require 'spec_helper'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,19 @@
 # encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require 'puppetlabs_spec_helper/module_spec_helper'
 


### PR DESCRIPTION
Changes:

## 1.0.4

* improvement: reprioritize EtM-based MACs
* improvement: move SHA1 KEX algos from default to weak profile

## 1.0.3

* feature: remove legacy SSHv1 code
* feature: add back GCM cipher

## 1.0.2

* bugfix: pass allow_{tcp,agent}_forwarding from init to classes

## 1.0.1

* feature: add back puppet 3.4.3 support
* feature: make other SSH configuration options configurable
* improvement: added faq on locked accounts to readme